### PR TITLE
fix: psycopg2 2.9 upgrade causes utc error in django 2.2.x

### DIFF
--- a/build/cdcs/Dockerfile
+++ b/build/cdcs/Dockerfile
@@ -23,7 +23,7 @@ RUN mkdir -p /root/.config/pip
 COPY pip/$PIP_CONF/pip.conf /root/.config/pip
 
 # Install uwsgi
-RUN pip install uwsgi psycopg2
+RUN pip install uwsgi psycopg2==2.8.6
 
 # Clone git repo
 RUN git clone $CDCS_REPO $DOCKYARD_SRVPROJ


### PR DESCRIPTION
Downgrade psycopg2 to version 2.8.6 after release of version 2.9 that is causing a UTC error in Django 2.2.x. See https://github.com/psycopg/psycopg2/issues/1293