### PR TITLE
feat: make MongoDB optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,18 @@ Additional components can be added to the CDCS stack by providing `docker-compos
 Update the `COMPOSE_FILE` variable in the `.env` file to do so. More information can be found in on this option in the
 [documentation](https://docs.docker.com/compose/reference/envvars/#compose_file).
 
+### MongoDB
+
+In preparation for the release of CDCS 3.x, MongoDB becomes an optional component and 
+will not be part of the default stack. It will need to be added for any CDCS 2.x deployment.
+
+To add MongoDB to the CDCS stack, you can do the following:
+
+Update the `.env` file to deploy MongoDB:
+```
+COMPOSE_FILE=docker-compose.yml:mongo/docker-compose.yml
+```
+
 ### Elasticsearch
 
 Ongoing developments on the CDCS make use of Elasticsearch.

--- a/deploy/.env
+++ b/deploy/.env
@@ -1,3 +1,5 @@
+COMPOSE_FILE=docker-compose.yml:mongo/docker-compose.yml
+
 # TODO: Configure the deployment
 PROJECT_NAME=mdcs
 IMAGE_NAME=mdcs

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -16,20 +16,6 @@ services:
       - cdcs_static:/srv/curator_static
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf
       - ./nginx/${SERVER_CONF}.conf:/etc/nginx/templates/default.conf.template
-  curator_mongo:
-    image: mongo:${MONGO_VERSION}
-    container_name: ${PROJECT_NAME}_cdcs_mongo
-    restart: always
-    environment:
-      - MONGO_INITDB_ROOT_USERNAME=${MONGO_ADMIN_USER}
-      - MONGO_INITDB_ROOT_PASSWORD=${MONGO_ADMIN_PASS}
-      - MONGO_INITDB_DATABASE=${MONGO_DB}
-      - MONGO_USER=${MONGO_USER}
-      - MONGO_PASS=${MONGO_PASS}
-    volumes:
-      - mongo_data:/data/db/
-      - ./mongo/mongo-init.sh:/docker-entrypoint-initdb.d/mongo-init.sh:ro
-    command: "--auth"
   curator_postgres:
     image: postgres:${POSTGRES_VERSION}
     container_name: ${PROJECT_NAME}_cdcs_postgres
@@ -52,7 +38,6 @@ services:
     container_name: ${PROJECT_NAME}_cdcs
     restart: always
     depends_on:
-      - curator_mongo
       - curator_redis
       - curator_postgres
     volumes:
@@ -89,7 +74,6 @@ services:
       - ${PROJECT_NAME}
 
 volumes:
-  mongo_data:
   postgres_data:
   redis_data:
   cdcs_socket:

--- a/deploy/mongo/docker-compose.yml
+++ b/deploy/mongo/docker-compose.yml
@@ -1,0 +1,19 @@
+version: "3"
+services:
+  curator_mongo:
+    image: mongo:${MONGO_VERSION}
+    container_name: ${PROJECT_NAME}_cdcs_mongo
+    restart: always
+    environment:
+      - MONGO_INITDB_ROOT_USERNAME=${MONGO_ADMIN_USER}
+      - MONGO_INITDB_ROOT_PASSWORD=${MONGO_ADMIN_PASS}
+      - MONGO_INITDB_DATABASE=${MONGO_DB}
+      - MONGO_USER=${MONGO_USER}
+      - MONGO_PASS=${MONGO_PASS}
+    volumes:
+      - mongo_data:/data/db/
+      - ./mongo/mongo-init.sh:/docker-entrypoint-initdb.d/mongo-init.sh:ro
+    command: "--auth"
+
+volumes:
+  mongo_data:


### PR DESCRIPTION
Place MongoDB service in a separate docker-compose file and allow optionally adding it using the `COMPOSE_FILE` environment variable.